### PR TITLE
Add p2p order id to p2p transactions

### DIFF
--- a/app/src/main/java/org/kinecosystem/kinit/network/OfferService.kt
+++ b/app/src/main/java/org/kinecosystem/kinit/network/OfferService.kt
@@ -19,6 +19,7 @@ const val ERROR_TRANSACTION_FAILED = 100
 const val ERROR_REDEEM_COUPON_FAILED = 101
 const val ERROR_NO_GOOD_LEFT = 200
 private const val ERROR_UPDATE_TRANSACTION_TO_SERVER = 300
+private const val P2P_ORDER_ID = "1-kit-p2p"
 
 class OfferService(context: Context, private val offersApi: OffersApi, val userId: String,
     val repository: OffersRepository, val analytics: Analytics, val wallet: Wallet, val scheduler: Scheduler) {
@@ -177,7 +178,7 @@ class OfferService(context: Context, private val offersApi: OffersApi, val userI
         scheduler.executeOnBackground(object : Runnable {
             override fun run() {
                 try {
-                    val transactionId = wallet.sendTransactionSync(toAddress, amount)
+                    val transactionId = wallet.payForOrder(toAddress, amount, P2P_ORDER_ID)
                     wallet.updateBalanceSync()
                     wallet.retrieveTransactions()
                     if (transactionId != null && !transactionId.id().isEmpty()) {

--- a/app/src/main/java/org/kinecosystem/kinit/network/Wallet.kt
+++ b/app/src/main/java/org/kinecosystem/kinit/network/Wallet.kt
@@ -198,10 +198,6 @@ class Wallet(context: Context, dataStoreProvider: DataStoreProvider,
         return account.sendTransactionSync(toAddress, BigDecimal(amount), orderId)
     }
 
-    fun sendTransactionSync(toAddress: String, amount: Int): TransactionId {
-        return account.sendTransactionSync(toAddress, BigDecimal(amount))
-    }
-
     fun initKinWallet() {
         Log.d("OnboardingService", "#### try create Wallet")
         scheduler.executeOnBackground({


### PR DESCRIPTION
p2p type wasn't missing. just added p2p order id to p2p payment transactions and removed method that was no longer used.