### PR TITLE
Fix reward display when timeout is long

### DIFF
--- a/app/src/main/java/org/kinecosystem/kinit/viewmodel/earn/TaskRewardViewModel.kt
+++ b/app/src/main/java/org/kinecosystem/kinit/viewmodel/earn/TaskRewardViewModel.kt
@@ -101,10 +101,11 @@ class TaskRewardViewModel(private var timeoutCallback: TransactionTimeout? = nul
                     val timeDiff = System.currentTimeMillis() - taskService.lastSubmissionTime
                     if (submitted || submitFailed) {
                         Log.d(TAG, "timeout reached with taskState= ${taskRepository.taskState}")
+                        onTimeoutCompleted()
                         timeoutCallback?.onSubmitError()
                     } else if (taskRepository.taskState == TaskState.SHOWING_CAPTCHA) {
                         Log.d(TAG,
-                            "waitForReward, state is SHOWING_CAPTCHA will wait some more. taskState= ${taskRepository.taskState}")
+                            "timeout reached however state is SHOWING_CAPTCHA will wait some more. taskState= ${taskRepository.taskState}")
                         waitForReward(REWARD_TIMEOUT)
                     } else if (timeDiff < REWARD_TIMEOUT) {
                         Log.d(TAG,
@@ -112,15 +113,19 @@ class TaskRewardViewModel(private var timeoutCallback: TransactionTimeout? = nul
                         // wait some more
                         waitForReward(REWARD_TIMEOUT - timeDiff + SMALL_DELAY)
                     } else {
+                        onTimeoutCompleted()
                         Log.d(TAG, "timeout reached transaction error")
                         timeoutCallback?.onTransactionTimeout()
                     }
-                    // update balance anyway in case kin has been received
-                    walletService.updateBalance()
-                    walletService.retrieveTransactions()
                 }
             },
             timeout)
+    }
+
+    private fun onTimeoutCompleted(){
+        // when timeout is reached, update balance anyway in case kin has been received
+        walletService.updateBalance()
+        walletService.retrieveTransactions()
     }
 
 }

--- a/app/src/main/res/layout/task_reward_fragment.xml
+++ b/app/src/main/res/layout/task_reward_fragment.xml
@@ -105,10 +105,12 @@
             android:text="@string/your_new_balance"
             android:textColor="#ffffff"
             android:textSize="16sp"
+            android:visibility="invisible"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintHorizontal_bias="0.5"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@+id/balance_amount"/>
+            app:layout_constraintTop_toBottomOf="@+id/balance_amount"
+            app:visibilityOn="@{model.onTransactionComplete}"/>
 
         <TextView
             android:id="@+id/close_text"


### PR DESCRIPTION
1. Will now only update balance/transaction list after waiting has
completed since the update resets onEarnTransactionCompleted which
is used as a signal to initiate the reward received animations

2. 'Your new balance' text should only be displayed after the reward
has been received.